### PR TITLE
feat: 支持飞书新架构渲染框架

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -14,6 +14,16 @@ export class Template extends RecursiveTemplate {
     type: 'tt',
   };
 
+  createMiniComponents(components): any {
+    const result = super.createMiniComponents(components);
+
+    // TODO: 目前还没有比较好的办法去判断当前 taro 支持不支持 modifyThirdPartyLoopBody 这个方法
+    // 暂时不删除 slot 节点，等提升 taro 的依赖版本后再移除
+    // delete result.slot
+
+    return result;
+  }
+
   /**
    * 依据飞书小程序开发文档，editor 的 bindatfinder 事件是默认不设置的，设置回调函数会取消默认行为；
    * 但 taro 默认给每个事件设置 eh 事件处理函数；
@@ -27,5 +37,15 @@ export class Template extends RecursiveTemplate {
       );
     }
     return res;
+  };
+
+  modifyThirdPartyLoopBody = () => {
+    // 支持新架构，保证 slot 一定直接位于自定义组件下，避免被 template 包一层之后无法识别
+    return `<view tt:if="{{item.nn==='slot'}}" slot="{{item.name}}" id="{{item.uid}}">
+        <block tt:for="{{item.cn}}" tt:key="uid">
+          <template is="tmpl_0_container" data="{{i:item}}" />
+        </block>
+      </view>
+      <template tt:else is="tmpl_0_container" data="{{i:item}}" />`;
   };
 }

--- a/types/template.d.ts
+++ b/types/template.d.ts
@@ -11,5 +11,12 @@ export declare class Template extends RecursiveTemplate {
         key: string;
         type: string;
     };
+    createMiniComponents(components: any): any;
+    /**
+     * 依据飞书小程序开发文档，editor 的 bindatfinder 事件是默认不设置的，设置回调函数会取消默认行为；
+     * 但 taro 默认给每个事件设置 eh 事件处理函数；
+     * 因此这里利用一个开关属性调整了 editor 的模版。
+     */
     modifyTemplateResult: (res: string, nodeName: string) => string;
+    modifyThirdPartyLoopBody: () => string;
 }


### PR DESCRIPTION
新渲染框架中，slot 是直接位于组件下，中间不能嵌套 template 或者其他类型的组件，修改类似于支持支付宝 2.0

https://github.com/NervJS/taro/pull/10888

这个依赖 Taro 能力，所以需要 3.3.17 +，推荐是 3.4，因为已经加了兼容代码，可以维持现在的 3.3+。只需要发 1.0 版本就行

