### PR TITLE
bugfix: 修复 input/textarea生成不同template导致原生组件闪烁的问题。

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -76,6 +76,10 @@ export default class Lark extends TaroPlatformBase {
   modifyTemplate(): void {
     const { pc } = this.options;
     this.template.mergeComponents(this.ctx, pc ? pcComponents : baseComponents);
+    // 飞书input/textarea不需要根据focus状态生成不同的template.
+    const focusComponents = this.template.focusComponents;
+    focusComponents.delete('input');
+    focusComponents.delete('textarea');
   }
 
   /**


### PR DESCRIPTION
taro会给input/textarea，根据focus状态生成不同的模板。开发者如果使用了focus属性，会使得用户点击原生组件时组件闪烁。